### PR TITLE
Feature/ Add BaseFragment class

### DIFF
--- a/app/src/main/java/com/istanbul/qurio/ui/base/BaseFragment.kt
+++ b/app/src/main/java/com/istanbul/qurio/ui/base/BaseFragment.kt
@@ -1,0 +1,40 @@
+package com.istanbul.qurio.ui.base
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.viewbinding.ViewBinding
+
+abstract class BaseFragment<VB : ViewBinding>(
+    private val bindingInflater: (LayoutInflater, ViewGroup?, Boolean) -> VB
+) : Fragment() {
+
+    private var _binding: VB? = null
+    protected val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View {
+        _binding = bindingInflater(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    protected fun setTitle(visibility: Boolean, title: String? = null) {
+        if (visibility) {
+            (activity as AppCompatActivity).supportActionBar?.show()
+            title?.let {
+                (activity as AppCompatActivity).supportActionBar?.title = it
+            }
+        } else {
+            (activity as AppCompatActivity).supportActionBar?.hide()
+        }
+    }
+}


### PR DESCRIPTION
You can use it like this for example

```kotlin
class HomeFragment : BaseFragment<FragmentHomeBinding>(FragmentHomeBinding::inflate) {
    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
        super.onViewCreated(view, savedInstanceState)

        // Access views directly using binding
        binding.textViewTitle.text = "Welcome to Home Screen"
        
        // and if you want to setTitle you can use the one of the base fragment
    }
}